### PR TITLE
Support multiple lambda deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,25 @@ Role Variables
 
 - `aws_account_id` - Required - The account id that you want to scan for objects.
 
-- `aws_profile_account` - Optional
 
-  If you run without supplying the variable `profile` and `region` it will use a role
-  `aws_profile_account` which will try to assume a IAM role
-  `profile_account_role_arn` to obtain the permission to do the task.
+- `iam_role_name` - Optional - Default:  'volume-management-iam-role'
+
+  The IAM role to run the lambda function as. The IAM role will be created by
+  this role to have enough permissions.
+
+- `lambda_function_name` - Optional - Default: "ec2_vol_management"
+
+  If you want to deploy multiple lambda for different type of volumes you can
+  call this role and override the `lambda_function_name` and per each call set
+  the `lambda_environment` (see below) differently.
+
+- `lambda_runtime` - Optional - Default: python2.7
+
+
+- `lambda_scheduled_rule_expression` - Optional - Default:  'cron(0 12 * * ? *)'
+
+  Default run daily. Note that this is GMT time in aws event
+
 
 - `lambda_environment` - Optional - A dict to set the env variable for the python script
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,18 @@
 ---
-# tasks file for ansible-role-ec2-volume-management
-- include_role:
-   name: aws_profile_account
-  vars:
-# iam role arn for this ec2 I am running to assume so that I have the
-# permission to do this tasks
-    aws_profile_account_role_arn: "{{ profile_account_role_arn|default() }}"
-    aws_profile_account_role_session_name: 'role: ec2-volume-management'
-    aws_profile_account_region: "{{ profile_account_region|default(region|default()) }}"
-  when: not profile|default()
-
-- name: set credentials fact
-  set_fact:
-    sts_creds: "{{ (sts_result|default({})).sts_creds|default({}) }}"
-  no_log: yes
-
 - name: Get tempfile
   tempfile:
     state: directory
   register: tempfile
 
+- name: Create temporary symlink to the main python script to be sure the lambda function name match with filename
+  file:
+    path: "{{ tempfile.path }}/{{ lambda_function_name }}.py"
+    src: "{{ role_path }}/files/ec2_vol_management.py"
+    state: link
+
 - name: Create zip file
   archive:
-    path: "{{ role_path }}/files/{{ lambda_function_name }}.py"
+    path: "{{ tempfile.path }}/{{ lambda_function_name }}.py"
     dest: "{{ tempfile.path }}/{{ lambda_function_name }}.zip"
     format: zip
 
@@ -31,9 +21,6 @@
   vars:
     aws_lambda_profile: "{{ profile|default() }}"
     aws_lambda_region: "{{ region|default() }}"
-    aws_lambda_access_key: "{{ sts_creds.access_key|default() }}"
-    aws_lambda_secret_key: "{{ sts_creds.secret_key|default() }}"
-    aws_lambda_security_token: "{{ sts_creds.session_token|default() }}"
     aws_lambda_function_name: "{{ lambda_function_name }}"
     aws_lambda_handler: "{{ lambda_function_name }}.lambda_handler"
     aws_lambda_runtime: "{{ lambda_runtime }}"


### PR DESCRIPTION
This change add support to deploy multiple lambda functions to allow different
volumes scanning and operation criterias.

Also remove the dependencies on role aws_profile_account.